### PR TITLE
docs: Add Gemini CLI Edition integration to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,5 +222,11 @@ The more high-quality examples you provide, the less the AI has to guess, and th
 
 - **Trust the Workflow:** It might seem like extra work to write a detailed `INITIAL.md` and review a PRP, but this upfront investment saves a massive amount of time on debugging and refactoring later.
 
+## 💡 Community Integrations & Adaptations
+
+ **[Gemini CLI Edition](https://github.com/e2720pjk/context-engineering-gemini)**: An
+adaptation of this template specifically for users of the `gemini-cli` tool. It replaces the shell
+scripts with custom commands for a more integrated workflow.
+
 ## Acknowledgements
 This project's workflow and the core concepts of Context Engineering were inspired by the original [Context-Engineering-Intro](https://github.com/coleam00/context-engineering-intro) repository by coleam00. While the code and templates have been rewritten for a Gemini-based workflow, the foundational ideas come from that excellent project.


### PR DESCRIPTION
Hello, I've referenced your version and tried migrating it to GeminiCLI. I've converted the original shell script to a GeminiCLI custom command.

This pull request simply adds a reference link to our version in the readme. Feel free to check if the CLI version works better.

## Commit Change
- Introduce a new section "Community Integrations & Adaptations".
- Add a link to the Gemini CLI Edition, highlighting its adaptation for `gemini-cli` users.
- Ensure the file ends with a newline character.

## Summary by Sourcery

Add a new section to the README linking to the Gemini CLI Edition integration for gemini-cli users

Documentation:
- Introduce a "Community Integrations & Adaptations" section to the README
- Add a link to the Gemini CLI Edition repository with a description of its custom commands adaptation